### PR TITLE
Allow having controller method params array in filters

### DIFF
--- a/core/MY_Controller.php
+++ b/core/MY_Controller.php
@@ -26,12 +26,12 @@ class MY_Controller extends CI_Controller {
     // Utilize _remap to call the filters at respective times
     public function _remap($method, $params = array())
     {
-        $this->before_filter();
+        $this->before_filter($params);
         if (method_exists($this, $method))
         {
             empty($params) ? $this->{$method}() : call_user_func_array(array($this, $method), $params);
         }
-        $this->after_filter();
+        $this->after_filter($params);
     }
 
     // Allows for before_filter and after_filter to be called without aliases


### PR DESCRIPTION
Hi again,

I hope it's not getting annoying me poking around at your code but I found most of your stuff quite useful. Anyway, I've read your [post](http://matthewmachuga.com/post/7181182435/codeigniter-filter-revisited) about CodeIgniter controller filters and in one example you showed how to DRY out controllers by adding a separate method for fetching the resource (in your example `get_resource()`). Well, this doesn't work with your current code here on github, so I decided to take a look at it.

Turns out filters don't get the params array, therefore doing something like this `$id = $params[0];` inside the filter isn't possible. I fixed the problem but I'm not sure if that's how you intended it to be.

I'll probably make my own controller filter support based on your code to better suit for my liking.

Cheers.
