### PR TITLE
Fixed $params for get_resource callback

### DIFF
--- a/core/MY_Controller.php
+++ b/core/MY_Controller.php
@@ -26,12 +26,12 @@ class MY_Controller extends CI_Controller {
     // Utilize _remap to call the filters at respective times
     public function _remap($method, $params = array())
     {
-        $this->before_filter();
+        $this->before_filter($params);
         if (method_exists($this, $method))
         {
             empty($params) ? $this->{$method}() : call_user_func_array(array($this, $method), $params);
         }
-        $this->after_filter();
+        $this->after_filter($params);
     }
 
     // Allows for before_filter and after_filter to be called without aliases


### PR DESCRIPTION
Per @machuga's [post on Tumblr](http://machuga.tumblr.com/post/7181182435/codeigniter-filter-revisited), there was a get_resource callback
which preloads resources in a before_filter allowing controller
methods to focus on view logic.

I find the $params in `_remap()` is actually router segments as
opposed to POST parameters as is in Rails.
